### PR TITLE
Updating technic with the ability to work with farming_undo

### DIFF
--- a/technic/machines/register/electric_furnace_recipes.lua
+++ b/technic/machines/register/electric_furnace_recipes.lua
@@ -1,14 +1,14 @@
 local S = technic.getter
 
--- This is a roundabout way to use cans with furnaces which cannot be 
+-- This is a roundabout way to use cans with furnaces which cannot be
 -- achieved using the standard "cooking" recipe.
 -- Alternatively, "heating" recipes can be used to provide non-cooking-compatible recipes
 -- such as those with multiple output materials. Those recipes would only be usable in
 -- technic furnaces.
 
-technic.register_recipe_type("heating", { 
-	description = S("Heating"), 
-	icon = "technic_recipe_icon_heating.png", 
+technic.register_recipe_type("heating", {
+	description = S("Heating"),
+	icon = "technic_recipe_icon_heating.png",
 	output_size = 2, })
 
 function technic.register_electric_furnace_recipe(data)
@@ -19,6 +19,11 @@ end
 local recipes = {}
 
 if minetest.get_modpath("farming") and farming.mod and farming.mod == "redo" then
+	table.insert(recipes, {"technic:water_can", {"farming:salt"}, 7})
+	table.insert(recipes, {"technic:water_jumbo_can", {"farming:salt"}, 7})
+end
+
+if minetest.get_modpath("farming") and farming.mod and farming.mod == "undo" then
 	table.insert(recipes, {"technic:water_can", {"farming:salt"}, 7})
 	table.insert(recipes, {"technic:water_jumbo_can", {"farming:salt"}, 7})
 end

--- a/technic/machines/register/grinder_recipes.lua
+++ b/technic/machines/register/grinder_recipes.lua
@@ -1,7 +1,7 @@
 
 local S = technic.getter
 
-technic.register_recipe_type("grinding", { 
+technic.register_recipe_type("grinding", {
 	description = S("Grinding"),
 	icon = "technic_recipe_icon_grinding.png", })
 
@@ -35,14 +35,14 @@ local recipes = {
 	{"doors:door_steel",           "technic:wrought_iron_dust 6"},
 	{"default:sign_wall_steel",    "technic:wrought_iron_dust 2"},
 	{"default:sign_wall_wood",     "technic:sawdust 8"},
-	
+
 	-- Other
 	{"default:cobble",          "default:gravel"},
 	{"default:gravel",          "default:sand"},
 	{"technic:stone_dust",      "default:silver_sand"},
-	
+
 	-- sands: reverse recipes can be found in the compressor
-	{"default:sandstone",       "default:sand 2"}, 
+	{"default:sandstone",       "default:sand 2"},
 	{"default:silver_sandstone","default:silver_sand 2"},
 	{"default:desert_sandstone","default:desert_sand 2"},
 }
@@ -71,7 +71,7 @@ end
 if minetest.get_modpath("farming") then
 	table.insert(recipes, {"farming:seed_wheat",   "farming:flour 1"})
 	table.insert(recipes, {"farming:seed_barley",   "farming:flour 1"})
-	
+
 	-- added by dhausmig
 	if minetest.registered_items["farming:corn"] ~= nil then
 		minetest.register_craftitem("technic:cornmeal", {
@@ -82,26 +82,31 @@ if minetest.get_modpath("farming") then
 			description = S("Cornbread"),
 			inventory_image = "technic_cornbread.png",
 			on_use = minetest.item_eat(8),
-      })
+		})
 
-      minetest.register_craft({
-		type = "cooking",
-		cooktime = 10,
-		output = "technic:cornbread",
-		recipe = "technic:cornmeal"
-      })
+		minetest.register_craft({
+			type = "cooking",
+			cooktime = 10,
+			output = "technic:cornbread",
+			recipe = "technic:cornmeal"
+		})
 
-      table.insert(recipes, {"farming:corn",   "technic:cornmeal 2"})
+		table.insert(recipes, {"farming:corn",   "technic:cornmeal 2"})
 	-- end of dhausmig's addition
 	end
-	
+
 	if farming.mod and farming.mod == "redo" then
 		table.insert(recipes, {"farming:seed_oat",   "farming:flour 1"})
 		table.insert(recipes, {"farming:seed_rye",   "farming:flour 1"})
 		table.insert(recipes, {"farming:rice",       "farming:rice_flour 1"})
 		table.insert(recipes, {"farming:seed_rice",  "farming:rice_flour 1"})
+	elseif farming.mod and farming.mod == "undo" then
+		table.insert(recipes, {"farming:seed_oat",   "farming:flour 1"})
+		table.insert(recipes, {"farming:seed_rye",   "farming:flour 1"})
+		table.insert(recipes, {"farming:rice",       "farming:rice_flour 1"})
+		table.insert(recipes, {"farming:seed_rice",  "farming:rice_flour 1"})
 	end
-	
+
 end
 
 if minetest.get_modpath("moreores") then

--- a/technic/machines/register/thresher_recipes.lua
+++ b/technic/machines/register/thresher_recipes.lua
@@ -4,7 +4,7 @@ local S = technic.getter
 
 technic.register_recipe_type("threshing", {
 	description = S("Threshing"),
-	icon = "technic_recipe_icon_threshing.png", 
+	icon = "technic_recipe_icon_threshing.png",
 	output_size = 2,
 })
 
@@ -18,31 +18,31 @@ local recipes = {
 
 if minetest.get_modpath("bushes_classic") then
 	for _, berry in ipairs({ "blackberry", "blueberry", "gooseberry", "raspberry", "strawberry" }) do
-		table.insert(recipes, { input = "bushes:"..berry.."_bush", 
+		table.insert(recipes, { input = "bushes:"..berry.."_bush",
 		                        output = {"default:stick 20", "bushes:"..berry.." 4" }})
 	end
 end
 
 if minetest.get_modpath("farming") then
-	
-	table.insert(recipes, { input = "farming:hemp_leaf", 
+
+	table.insert(recipes, { input = "farming:hemp_leaf",
 	                        output = {"farming:hemp_fibre"}})
-	table.insert(recipes, { input = "farming:seed_hemp 3", 
+	table.insert(recipes, { input = "farming:seed_hemp 3",
 	                        output = {"farming:hemp_fibre"}})
 
 	if minetest.get_modpath("cottages") and cottages.mod and cottages.mod == "linuxforks" then
 		-- work as a mechanized threshing floor from cottages
-		table.insert(recipes, { input = "farming:wheat", 
+		table.insert(recipes, { input = "farming:wheat",
 		                        output = {"farming:seed_wheat", "cottages:straw_mat"} })
-		table.insert(recipes, { input = "farming:barley", 
+		table.insert(recipes, { input = "farming:barley",
 		                        output = {"farming:seed_barley", "cottages:straw_mat"} })
--- 		table.insert(recipes, { input = "farming:corn", 
+-- 		table.insert(recipes, { input = "farming:corn",
 -- 		                        output = {"farming:corn", "cottages:hay_mat"} })
 	else
 		-- work in a less fancy and less efficient manner
-		table.insert(recipes, { input = "farming:wheat 4", 
+		table.insert(recipes, { input = "farming:wheat 4",
 		                        output = {"farming:seed_wheat 3", "default:dry_shrub 1"} })
-		table.insert(recipes, { input = "farming:barley 4", 
+		table.insert(recipes, { input = "farming:barley 4",
 		                        output = {"farming:seed_barley 3", "default:dry_shrub 1"} })
 	end
 end
@@ -51,53 +51,86 @@ if minetest.get_modpath("farming") and farming.mod and farming.mod == "redo" the
 	-- farming redo uses recipes unfriendly with respect to automation. E.g. using the cutting board.
 	-- in the end, it's hard to automate a farm, since crops have to be processed individually.
 	-- here, we use the thresher to provide a universal device to deal with those
-	table.insert(recipes, { input = "farming:pumpkin_8", 
+	table.insert(recipes, { input = "farming:pumpkin_8",
 		                        output = {"farming:pumpkin_slice 5"} })
--- 	table.insert(recipes, { input = "farming:pumpkin", 
+-- 	table.insert(recipes, { input = "farming:pumpkin",
 -- 		                        output = {"farming:pumpkin_slice 5"} })
-	table.insert(recipes, { input = "farming:melon_8", 
+	table.insert(recipes, { input = "farming:melon_8",
 		                        output = {"farming:melon_slice 5"} })
-	table.insert(recipes, { input = "farming:pineapple", 
+	table.insert(recipes, { input = "farming:pineapple",
 		                        output = {"farming:pineapple_ring 6", "farming:pineapple_top"} })
-	table.insert(recipes, { input = "farming:garlic", 
+	table.insert(recipes, { input = "farming:garlic",
 		                        output = {"farming:garlic_clove 10"} })
-	table.insert(recipes, { input = "farming:pepper", 
+	table.insert(recipes, { input = "farming:pepper",
 		                        output = {"farming:peppercorn 2"} })
-	
+
 	if minetest.get_modpath("cottages") and cottages.mod and cottages.mod == "linuxforks" then
 		-- work as a mechanized threshing floor from cottages
-		table.insert(recipes, { input = "farming:oat", 
+		table.insert(recipes, { input = "farming:oat",
 		                        output = {"farming:seed_oat", "cottages:straw_mat"} })
-		table.insert(recipes, { input = "farming:rye", 
+		table.insert(recipes, { input = "farming:rye",
 		                        output = {"farming:seed_rye", "cottages:straw_mat"} })
 	else
 		-- work in a less fancy and less efficient manner
-		table.insert(recipes, { input = "farming:oat 4", 
+		table.insert(recipes, { input = "farming:oat 4",
 		                        output = {"farming:seed_oat 3", "default:dry_shrub 1"} })
-		table.insert(recipes, { input = "farming:rye 4", 
+		table.insert(recipes, { input = "farming:rye 4",
 		                        output = {"farming:seed_rye 3", "default:dry_shrub 1"} })
 	end
-	
+
+end
+
+if minetest.get_modpath("farming") and farming.mod and farming.mod == "undo" then
+	-- farming undo uses recipes unfriendly with respect to automation. E.g. using the cutting board.
+	-- in the end, it's hard to automate a farm, since crops have to be processed individually.
+	-- here, we use the thresher to provide a universal device to deal with those
+	table.insert(recipes, { input = "farming:pumpkin_8",
+		                        output = {"farming:pumpkin_slice 5"} })
+-- 	table.insert(recipes, { input = "farming:pumpkin",
+-- 		                        output = {"farming:pumpkin_slice 5"} })
+	table.insert(recipes, { input = "farming:melon_8",
+		                        output = {"farming:melon_slice 5"} })
+	table.insert(recipes, { input = "farming:pineapple",
+		                        output = {"farming:pineapple_ring 6", "farming:pineapple_top"} })
+	table.insert(recipes, { input = "farming:garlic",
+		                        output = {"farming:garlic_clove 10"} })
+	table.insert(recipes, { input = "farming:pepper",
+		                        output = {"farming:peppercorn 2"} })
+
+	if minetest.get_modpath("cottages") and cottages.mod and cottages.mod == "linuxforks" then
+		-- work as a mechanized threshing floor from cottages
+		table.insert(recipes, { input = "farming:oat",
+		                        output = {"farming:seed_oat", "cottages:straw_mat"} })
+		table.insert(recipes, { input = "farming:rye",
+		                        output = {"farming:seed_rye", "cottages:straw_mat"} })
+	else
+		-- work in a less fancy and less efficient manner
+		table.insert(recipes, { input = "farming:oat 4",
+		                        output = {"farming:seed_oat 3", "default:dry_shrub 1"} })
+		table.insert(recipes, { input = "farming:rye 4",
+		                        output = {"farming:seed_rye 3", "default:dry_shrub 1"} })
+	end
+
 end
 
 -- using thresher as a sorting machine for grass
 if minetest.get_modpath("cottages") and cottages.mod and cottages.mod == "linuxforks" then
-	table.insert(recipes, { input = "default:grass_1 99", 
-                        output = {"default:dry_grass_1 30", "cottages:hay_mat 50", "default:dry_shrub 7", "default:junglegrass 12"}, 
+	table.insert(recipes, { input = "default:grass_1 99",
+                        output = {"default:dry_grass_1 30", "cottages:hay_mat 50", "default:dry_shrub 7", "default:junglegrass 12"},
                         time = 16 })
 else
-	table.insert(recipes, { input = "default:grass_1 99", 
-                        output = {"default:dry_grass_1 80", "default:dry_shrub 7", "default:junglegrass 12"}, 
+	table.insert(recipes, { input = "default:grass_1 99",
+                        output = {"default:dry_grass_1 80", "default:dry_shrub 7", "default:junglegrass 12"},
                         time = 16 })
 
 end
 
 if minetest.get_modpath("ethereal") then
-	table.insert(recipes, { input = "default:junglegrass 99", 
-	                        output = {"ethereal:dry_shrub 10", "ethereal:crystalgrass 5", "ethereal:snowygrass 5" }, 
+	table.insert(recipes, { input = "default:junglegrass 99",
+	                        output = {"ethereal:dry_shrub 10", "ethereal:crystalgrass 5", "ethereal:snowygrass 5" },
 	                        time = 16 })
-	table.insert(recipes, { input = "default:dry_grass_1 99", 
-	                        output = {"ethereal:fern 5"}, 
+	table.insert(recipes, { input = "default:dry_grass_1 99",
+	                        output = {"ethereal:fern 5"},
 	                        time = 16 })
 end
 


### PR DESCRIPTION
The mod farming_undo is a fork of farming_redo. Adding the ability for farming_undo to work with the most recipes like rice, oat, rye, etc.